### PR TITLE
sidebar 를 제거하고, sidebar 에 있는 버튼을 header 로 이동

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import dash_bootstrap_components as dbc
-from dash import Dash, html, dcc, page_registry, page_container
+from dash import Dash, html, page_container
 
 external_stylesheets = [dbc.themes.BOOTSTRAP, dbc.icons.BOOTSTRAP, dbc.icons.FONT_AWESOME]
 app = Dash(__name__, use_pages=True, external_stylesheets=external_stylesheets)
@@ -13,6 +13,9 @@ navbar = dbc.Navbar(
                     [
                         dbc.Col(html.I(className="fa-solid fa-people-roof", style=dict(color="#FFFFFF"))),
                         dbc.Col(dbc.NavbarBrand("RooMBTI")),
+                        dbc.Col(dbc.NavLink("Overview", href="/", active="exact", style=dict(color="#FFFFFF"))),
+                        dbc.Col(dbc.NavLink("Users", href="/users", active="exact", style=dict(color="#FFFFFF"))),
+                        dbc.Col(dbc.NavLink("Comparison", href="/comparison", active="exact", style=dict(color="#FFFFFF"))),
                     ],
                     align="center",
                 ),
@@ -23,41 +26,12 @@ navbar = dbc.Navbar(
     dark=True,
 )
 
-SIDEBAR_STYLE = {
-    # "position": "fixed",
-    # "top": 0,
-    # "left": 0,
-    # "bottom": 0,
-    "float": "left",
-    "width": "16rem",
-    "height": "100%",
-    "padding": "2rem 1rem",
-    "background-color": "#f8f9fa",
-}
-
-sidebar = html.Div(
-    [
-        # html.H2("", className="display-4"),
-        html.P("Compare routines between me and roommate", className="lead"),
-        html.Hr(),
-        dbc.Nav(
-            [
-                dbc.NavLink("Overview", href="/", active="exact"),
-                dbc.NavLink("Users", href="/users", active="exact"),
-                dbc.NavLink("Comparison", href="/comparison", active="exact"),
-            ],
-            vertical=True,
-            pills=True,
-        ),
-    ],
-    style=SIDEBAR_STYLE,
-)
-
 app.layout = html.Div(
     [
-        html.Header(navbar),
-        sidebar,
-        page_container,
+        navbar,
+        dbc.Container(
+            dbc.Row(page_container)
+        )
     ]
 )
 


### PR DESCRIPTION
# 작업 내용

- sidebar 에 있던 버튼들을 헤더로 이동합니다.
![image](https://github.com/sjuuun/RooMBTI/assets/47017729/4e723472-ab5e-4756-9e72-1b92c2d56df6)
