### PR TITLE
dash bootstrap component 에서 width 를 조절하도록 변경

### DIFF
--- a/figures/bfi.py
+++ b/figures/bfi.py
@@ -16,7 +16,7 @@ def bfi_single(user_id: str) -> go.Figure:
             name=user_id
         )
     )
-    bfi_fig.update_layout(template="simple_white", width=500, height=500, title="BFI")
+    bfi_fig.update_layout(template="simple_white", title="BFI")
     return bfi_fig
 
 
@@ -41,7 +41,7 @@ def bfi_compare(me_id: str, roommate_id: str) -> go.Figure:
             name=roommate_id
         )
     )
-    bfi_fig.update_layout(template="simple_white", width=500, height=500, title="BFI")
+    bfi_fig.update_layout(template="simple_white", title="BFI")
     return bfi_fig
 
 

--- a/figures/indoor.py
+++ b/figures/indoor.py
@@ -47,7 +47,7 @@ def indoor(user_id: str) -> go.Figure:
     indoor_fig = go.Figure(data=[
                       go.Scatter(x=df.start_at, y=df.indoor_ratio, mode='lines', name='User')
                       ])
-    indoor_fig.update_layout(template='simple_white', title='Indoor', width=400, height=300)
+    indoor_fig.update_layout(template='simple_white', title='Indoor')
     indoor_fig.update_xaxes(tickformat="%H:%M")
     indoor_fig.update_yaxes(range=[0.0, 1.1])
     return indoor_fig
@@ -64,7 +64,7 @@ def indoor_compare(user_id: str, roommate_id: str) -> go.Figure:
                       go.Scatter(x=user_df.start_at, y=user_df.indoor_ratio, mode='lines', name='User'),
                       go.Scatter(x=roommate_df.start_at, y=roommate_df.indoor_ratio, mode='lines', name='Roommate')
                       ])
-    indoor_fig.update_layout(template='simple_white', title='Indoor', width=400, height=300)
+    indoor_fig.update_layout(template='simple_white', title='Indoor')
     indoor_fig.update_xaxes(tickformat="%H:%M")
     indoor_fig.update_yaxes(range=[0.0, 1.1])
     return indoor_fig

--- a/pages/comparison.py
+++ b/pages/comparison.py
@@ -31,13 +31,17 @@ layout = html.Div(children=[
                         min=0,
                         color="#346beb"
                     )
-                ])
+                ]),
+                width=2,
+                align='center'
             ),
             dbc.Col(
-                dcc.Graph(id='bfi', figure=bfi_compare(SAMPLE_ME_ID, SAMPLE_ROOMMATE_ID))
+                dcc.Graph(id='bfi', figure=bfi_compare(SAMPLE_ME_ID, SAMPLE_ROOMMATE_ID)),
+                width=5,
             ),
             dbc.Col(
-                dcc.Graph(id='indoor', figure=indoor.indoor_compare(SAMPLE_ME_ID, SAMPLE_ROOMMATE_ID))
+                dcc.Graph(id='indoor', figure=indoor.indoor_compare(SAMPLE_ME_ID, SAMPLE_ROOMMATE_ID)),
+                width=5
             ),
         ]),
         dbc.Row(

--- a/pages/overview.py
+++ b/pages/overview.py
@@ -24,12 +24,16 @@ layout = html.Div(children=[
             dbc.Col([
                 dbc.Row(matched()),
                 dbc.Row(top_3())
-            ]),
+            ],
+                width=2,
+                align='center'),
             dbc.Col(
-                dcc.Graph(id='bfi', figure=bfi_single(SAMPLE_ME_ID))
+                dcc.Graph(id='bfi', figure=bfi_single(SAMPLE_ME_ID)),
+                width=5,
             ),
             dbc.Col(
-                dcc.Graph(id='indoor', figure=indoor.indoor(SAMPLE_ME_ID))
+                dcc.Graph(id='indoor', figure=indoor.indoor(SAMPLE_ME_ID)),
+                width=5,
             ),
         ]),
         dbc.Row(


### PR DESCRIPTION
# 내용

- 그래프들 사이의 align 을 개선하기 위해서, 각 plot 별로 width 및 height 를 조절하는 것이 아니라, dash bootstrap component 의 width 를 사용합니다.
- 결과
![image](https://github.com/sjuuun/RooMBTI/assets/47017729/6d826baf-b69b-448c-ac98-5747ee36ca91)
